### PR TITLE
Add inline attribute to small public functions

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -12,6 +12,7 @@ use crate::check_length;
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn abs_f32(src: &[f32], dst: &mut [f32]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -27,6 +28,7 @@ pub fn abs_f32(src: &[f32], dst: &mut [f32]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn abs_q31(src: &[I1F31], dst: &mut [I1F31]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -42,6 +44,7 @@ pub fn abs_q31(src: &[I1F31], dst: &mut [I1F31]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn abs_q15(src: &[I1F15], dst: &mut [I1F15]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -57,6 +60,7 @@ pub fn abs_q15(src: &[I1F15], dst: &mut [I1F15]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn abs_q7(src: &[I1F7], dst: &mut [I1F7]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -68,6 +72,7 @@ pub fn abs_q7(src: &[I1F7], dst: &mut [I1F7]) {
 ///
 /// This is functionally equivalent to performing `values[i] = abs(values[i])` for all values of i
 /// in range.
+#[inline]
 pub fn abs_in_place_f32(values: &mut [f32]) {
     let length = check_length(values.len());
     // The CMSIS DSP function specifically does support argument aliasing. Is this really safe
@@ -82,6 +87,7 @@ pub fn abs_in_place_f32(values: &mut [f32]) {
 ///
 /// This is functionally equivalent to performing `values[i] = abs(values[i])` for all values of i
 /// in range.
+#[inline]
 pub fn abs_in_place_q31(values: &mut [I1F31]) {
     let length = check_length(values.len());
     unsafe {
@@ -94,6 +100,7 @@ pub fn abs_in_place_q31(values: &mut [I1F31]) {
 ///
 /// This is functionally equivalent to performing `values[i] = abs(values[i])` for all values of i
 /// in range.
+#[inline]
 pub fn abs_in_place_q15(values: &mut [I1F15]) {
     let length = check_length(values.len());
     unsafe {
@@ -106,6 +113,7 @@ pub fn abs_in_place_q15(values: &mut [I1F15]) {
 ///
 /// This is functionally equivalent to performing `values[i] = abs(values[i])` for all values of i
 /// in range.
+#[inline]
 pub fn abs_in_place_q7(values: &mut [I1F7]) {
     let length = check_length(values.len());
     unsafe {
@@ -122,6 +130,7 @@ pub fn abs_in_place_q7(values: &mut [I1F7]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn add_f32(src1: &[f32], src2: &[f32], dst: &mut [f32]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -137,6 +146,7 @@ pub fn add_f32(src1: &[f32], src2: &[f32], dst: &mut [f32]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn add_q31(src1: &[I1F31], src2: &[I1F31], dst: &mut [I1F31]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -157,6 +167,7 @@ pub fn add_q31(src1: &[I1F31], src2: &[I1F31], dst: &mut [I1F31]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn add_q15(src1: &[I1F15], src2: &[I1F15], dst: &mut [I1F15]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -177,6 +188,7 @@ pub fn add_q15(src1: &[I1F15], src2: &[I1F15], dst: &mut [I1F15]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn add_q7(src1: &[I1F7], src2: &[I1F7], dst: &mut [I1F7]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -197,6 +209,7 @@ pub fn add_q7(src1: &[I1F7], src2: &[I1F7], dst: &mut [I1F7]) {
 /// # Panics
 ///
 /// This function panics if src1 and src2 do not have the same length.
+#[inline]
 pub fn dot_product_f32(src1: &[f32], src2: &[f32]) -> f32 {
     let length = check_length((src1.len(), src2.len()));
     let mut result = 0.0;
@@ -214,6 +227,7 @@ pub fn dot_product_f32(src1: &[f32], src2: &[f32]) -> f32 {
 /// # Panics
 ///
 /// This function panics if src1 and src2 do not have the same length.
+#[inline]
 pub fn dot_product_q31(src1: &[I1F31], src2: &[I1F31]) -> I16F48 {
     let length = check_length((src1.len(), src2.len()));
     let mut result = I16F48::from_bits(0);
@@ -236,6 +250,7 @@ pub fn dot_product_q31(src1: &[I1F31], src2: &[I1F31]) -> I16F48 {
 /// # Panics
 ///
 /// This function panics if src1 and src2 do not have the same length.
+#[inline]
 pub fn dot_product_q15(src1: &[I1F15], src2: &[I1F15]) -> I34F30 {
     let length = check_length((src1.len(), src2.len()));
     let mut result = I34F30::from_bits(0);
@@ -258,6 +273,7 @@ pub fn dot_product_q15(src1: &[I1F15], src2: &[I1F15]) -> I34F30 {
 /// # Panics
 ///
 /// This function panics if src1 and src2 do not have the same length.
+#[inline]
 pub fn dot_product_q7(src1: &[I1F7], src2: &[I1F7]) -> I18F14 {
     let length = check_length((src1.len(), src2.len()));
     let mut result = I18F14::from_bits(0);
@@ -280,6 +296,7 @@ pub fn dot_product_q7(src1: &[I1F7], src2: &[I1F7]) -> I18F14 {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn multiply_f32(src1: &[f32], src2: &[f32], dst: &mut [f32]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -295,6 +312,7 @@ pub fn multiply_f32(src1: &[f32], src2: &[f32], dst: &mut [f32]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn multiply_q31(src1: &[I1F31], src2: &[I1F31], dst: &mut [I1F31]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -315,6 +333,7 @@ pub fn multiply_q31(src1: &[I1F31], src2: &[I1F31], dst: &mut [I1F31]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn multiply_q15(src1: &[I1F15], src2: &[I1F15], dst: &mut [I1F15]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -335,6 +354,7 @@ pub fn multiply_q15(src1: &[I1F15], src2: &[I1F15], dst: &mut [I1F15]) {
 /// # Panics
 ///
 /// This function panics if src1, src2, and dst do not have the same length.
+#[inline]
 pub fn multiply_q7(src1: &[I1F7], src2: &[I1F7], dst: &mut [I1F7]) {
     let length = check_length((src1.len(), src2.len(), dst.len()));
     unsafe {
@@ -355,6 +375,7 @@ pub fn multiply_q7(src1: &[I1F7], src2: &[I1F7], dst: &mut [I1F7]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn negate_f32(src: &[f32], dst: &mut [f32]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -370,6 +391,7 @@ pub fn negate_f32(src: &[f32], dst: &mut [f32]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn negate_q31(src: &[I1F31], dst: &mut [I1F31]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -385,6 +407,7 @@ pub fn negate_q31(src: &[I1F31], dst: &mut [I1F31]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn negate_q15(src: &[I1F15], dst: &mut [I1F15]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -400,6 +423,7 @@ pub fn negate_q15(src: &[I1F15], dst: &mut [I1F15]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn negate_q7(src: &[I1F7], dst: &mut [I1F7]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -411,6 +435,7 @@ pub fn negate_q7(src: &[I1F7], dst: &mut [I1F7]) {
 ///
 /// This is functionally equivalent to performing `values[i] = -values[i]` for all values of i
 /// in range.
+#[inline]
 pub fn negate_in_place_f32(values: &mut [f32]) {
     let length = check_length(values.len());
     unsafe {
@@ -423,6 +448,7 @@ pub fn negate_in_place_f32(values: &mut [f32]) {
 ///
 /// This is functionally equivalent to performing `values[i] = -values[i]` for all values of i
 /// in range.
+#[inline]
 pub fn negate_in_place_q31(values: &mut [I1F31]) {
     let length = check_length(values.len());
     unsafe {
@@ -435,6 +461,7 @@ pub fn negate_in_place_q31(values: &mut [I1F31]) {
 ///
 /// This is functionally equivalent to performing `values[i] = -values[i]` for all values of i
 /// in range.
+#[inline]
 pub fn negate_in_place_q15(values: &mut [I1F15]) {
     let length = check_length(values.len());
     unsafe {
@@ -447,6 +474,7 @@ pub fn negate_in_place_q15(values: &mut [I1F15]) {
 ///
 /// This is functionally equivalent to performing `values[i] = -values[i]` for all values of i
 /// in range.
+#[inline]
 pub fn negate_in_place_q7(values: &mut [I1F7]) {
     let length = check_length(values.len());
     unsafe {
@@ -463,6 +491,7 @@ pub fn negate_in_place_q7(values: &mut [I1F7]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn shift_q15(src: &[I1F15], shift_bits: i8, dst: &mut [I1F15]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -478,6 +507,7 @@ pub fn shift_q15(src: &[I1F15], shift_bits: i8, dst: &mut [I1F15]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn shift_q31(src: &[I1F31], shift_bits: i8, dst: &mut [I1F31]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -493,6 +523,7 @@ pub fn shift_q31(src: &[I1F31], shift_bits: i8, dst: &mut [I1F31]) {
 /// # Panics
 ///
 /// This function panics if src and dst do not have the same length.
+#[inline]
 pub fn shift_q7(src: &[I1F7], shift_bits: i8, dst: &mut [I1F7]) {
     let length = check_length((src.len(), dst.len()));
     unsafe {
@@ -504,6 +535,7 @@ pub fn shift_q7(src: &[I1F7], shift_bits: i8, dst: &mut [I1F7]) {
 ///
 /// This is functionally equivalent to performing `values[i] = values[i] << shiftBits` for all values of i
 /// in range. Positive values shift left, negative values shift right.
+#[inline]
 pub fn shift_in_place_q15(values: &mut [I1F15], shift_bits: i8) {
     let length = check_length(values.len());
     unsafe {
@@ -516,6 +548,7 @@ pub fn shift_in_place_q15(values: &mut [I1F15], shift_bits: i8) {
 ///
 /// This is functionally equivalent to performing `values[i] = values[i] << shiftBits` for all values of i
 /// in range. Positive values shift left, negative values shift right.
+#[inline]
 pub fn shift_in_place_q31(values: &mut [I1F31], shift_bits: i8) {
     let length = check_length(values.len());
     unsafe {
@@ -528,6 +561,7 @@ pub fn shift_in_place_q31(values: &mut [I1F31], shift_bits: i8) {
 ///
 /// This is functionally equivalent to performing `values[i] = values[i] << shiftBits` for all values of i
 /// in range. Positive values shift left, negative values shift right.
+#[inline]
 pub fn shift_in_place_q7(values: &mut [I1F7], shift_bits: i8) {
     let length = check_length(values.len());
     unsafe {

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -11,6 +11,7 @@ use crate::check_length;
 ///
 /// This function panics if source.len() is not equal to destination.len(), or if either length
 /// is too large to fit into a 32-bit integer
+#[inline]
 pub fn complex_magnitude_f32(source: &[Complex32], destination: &mut [f32]) {
     let length = check_length((source.len(), destination.len()));
     unsafe {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -45,6 +45,7 @@ impl FloatRealFft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u16) -> Result<Self> {
         let mut data = MaybeUninit::<cmsis_dsp_sys::arm_rfft_fast_instance_f32>::uninit();
         unsafe {
@@ -58,6 +59,7 @@ impl FloatRealFft {
     /// # Panics
     ///
     /// This function panics if input or output has a length not equal to the size of this FFT.
+    #[inline]
     pub fn run(&self, input: &mut [f32], output: &mut [f32]) {
         self.run_inner(input, output, Direction::Forward);
     }
@@ -66,6 +68,7 @@ impl FloatRealFft {
     /// # Panics
     ///
     /// This function panics if input or output has a length not equal to the size of this FFT.
+    #[inline]
     pub fn run_inverse(&self, input: &mut [f32], output: &mut [f32]) {
         self.run_inner(input, output, Direction::Inverse);
     }
@@ -98,6 +101,7 @@ impl Q15RealFft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u32, direction: Direction, output_order: OutputOrder) -> Result<Self> {
         let mut data = MaybeUninit::<cmsis_dsp_sys::arm_rfft_instance_q15>::uninit();
         unsafe {
@@ -120,6 +124,7 @@ impl Q15RealFft {
     /// The output type depends on the size of the FFT. To determine how to interpret the output
     /// bits, refer to the table in the arm_rfft_q15 function documentation
     /// at https://www.keil.com/pack/doc/cmsis/DSP/html/group__RealFFT.html#ga00e615f5db21736ad5b27fb6146f3fc5 .
+    #[inline]
     pub fn run(&self, input: &mut [I1F15], output: &mut [i16]) {
         // From ARM docs: If the input buffer is of length N (fftLenReal), the output buffer must have length 2N
         // since it is containing the conjugate part (except for MVE version where N+2 is enough).
@@ -141,6 +146,7 @@ impl Q31RealFft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u32, direction: Direction, output_order: OutputOrder) -> Result<Self> {
         let mut data = MaybeUninit::<cmsis_dsp_sys::arm_rfft_instance_q31>::uninit();
         unsafe {
@@ -163,6 +169,7 @@ impl Q31RealFft {
     /// The output type depends on the size of the FFT. To determine how to interpret the output
     /// bits, refer to the table in the arm_rfft_q31 function documentation
     /// at https://www.keil.com/pack/doc/cmsis/DSP/html/group__RealFFT.html#gabaeab5646aeea9844e6d42ca8c73fe3a .
+    #[inline]
     pub fn run(&self, input: &mut [I1F31], output: &mut [i32]) {
         // From ARM docs: If the input buffer is of length N (fftLenReal), the output buffer must have length 2N
         // since it is containing the conjugate part (except for MVE version where N+2 is enough).
@@ -188,6 +195,7 @@ impl FloatFft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u16) -> Result<Self> {
         let instance = unsafe {
             match size {
@@ -207,6 +215,7 @@ impl FloatFft {
     }
 
     /// Runs the FFT in-place on a buffer of values
+    #[inline]
     pub fn run(&self, data: &mut [Complex32], direction: Direction, output_order: OutputOrder) {
         unsafe {
             // FFT size is number of complex values. arm_cfft_f32 expects size * 2 float values.
@@ -226,6 +235,7 @@ impl FloatFft {
 ///
 /// This can offer slightly better performance than FloatFft because it skips the data
 /// length check.
+#[inline]
 pub fn float_fft_128(data: &mut [Complex32; 128], direction: Direction, output_order: OutputOrder) {
     unsafe {
         cmsis_dsp_sys::arm_cfft_f32(
@@ -251,6 +261,7 @@ pub trait FftBuffer {
 }
 
 impl FftBuffer for [Complex32; 16] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -263,6 +274,7 @@ impl FftBuffer for [Complex32; 16] {
     }
 }
 impl FftBuffer for [Complex32; 32] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -275,6 +287,7 @@ impl FftBuffer for [Complex32; 32] {
     }
 }
 impl FftBuffer for [Complex32; 64] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -287,6 +300,7 @@ impl FftBuffer for [Complex32; 64] {
     }
 }
 impl FftBuffer for [Complex32; 128] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -299,6 +313,7 @@ impl FftBuffer for [Complex32; 128] {
     }
 }
 impl FftBuffer for [Complex32; 256] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -311,6 +326,7 @@ impl FftBuffer for [Complex32; 256] {
     }
 }
 impl FftBuffer for [Complex32; 512] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -323,6 +339,7 @@ impl FftBuffer for [Complex32; 512] {
     }
 }
 impl FftBuffer for [Complex32; 1024] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -335,6 +352,7 @@ impl FftBuffer for [Complex32; 1024] {
     }
 }
 impl FftBuffer for [Complex32; 2048] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -347,6 +365,7 @@ impl FftBuffer for [Complex32; 2048] {
     }
 }
 impl FftBuffer for [Complex32; 4096] {
+    #[inline]
     fn run_fft(&mut self, direction: Direction, output_order: OutputOrder) {
         unsafe {
             cmsis_dsp_sys::arm_cfft_f32(
@@ -376,6 +395,7 @@ impl Q15Fft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u16, direction: Direction, output_order: OutputOrder) -> Result<Self> {
         let instance = unsafe {
             match size {
@@ -400,6 +420,7 @@ impl Q15Fft {
     }
 
     /// Runs the FFT in-place on a buffer of values
+    #[inline]
     pub fn run(&self, data: &mut [Complex<I1F15>]) {
         unsafe {
             // FFT size is number of complex values. arm_cfft_q15 expects size * 2 u16 values.
@@ -428,6 +449,7 @@ impl Q31Fft {
     ///
     /// Valid size values are 32, 64, 128, 256, 512, 1024, 2048, and 4096. This function returns
     /// an error if the size value is not valid.
+    #[inline]
     pub fn new(size: u16) -> Result<Self> {
         let instance = unsafe {
             match size {
@@ -447,6 +469,7 @@ impl Q31Fft {
     }
 
     /// Runs the FFT in-place on a buffer of values
+    #[inline]
     pub fn run(
         &self,
         data: &mut [Complex<I1F31>],


### PR DESCRIPTION
Most functions are wrappers around a single FFI call, so helping with cross-crate inlining makes sens in case you're not using LTO. 

Stacked on #6, so I can rebase or whatever depending on how you like to do things.